### PR TITLE
[PATCH] utils.named_pipe: rewrite named pipes

### DIFF
--- a/src/streamlink/plugin/api/validate.py
+++ b/src/streamlink/plugin/api/validate.py
@@ -16,7 +16,10 @@
 """
 
 from copy import copy as copy_obj
-from typing import Any, Tuple, Union
+try:
+    from typing import Any, Tuple, Union
+except ImportError:
+    pass
 from xml.etree import ElementTree as ET
 
 try:
@@ -97,13 +100,13 @@ class attr(SchemaContainer):
     """Validates an object's attributes."""
 
 
-class union_get:
+class union_get(object):
     def __init__(self, *keys, **kw):
         self.keys = keys
         self.seq = kw.get("seq", tuple)
 
 
-class xml_element:
+class xml_element(object):
     """A XML element."""
 
     def __init__(self, tag=None, text=None, attrib=None):

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -1,6 +1,4 @@
 import logging
-import os
-import random
 import subprocess
 import sys
 import threading
@@ -61,7 +59,7 @@ class FFMPEGMuxer(StreamIO):
     @staticmethod
     def copy_to_pipe(self, stream, pipe):
         log.debug("Starting copy to pipe: {0}".format(pipe.path))
-        pipe.open("wb")
+        pipe.open()
         while not stream.closed:
             try:
                 data = stream.read(8192)
@@ -86,7 +84,7 @@ class FFMPEGMuxer(StreamIO):
         self.process = None
         self.streams = streams
 
-        self.pipes = [NamedPipe("ffmpeg-{0}-{1}".format(os.getpid(), random.randint(0, 1000))) for _ in self.streams]
+        self.pipes = [NamedPipe() for _ in self.streams]
         self.pipe_threads = [threading.Thread(target=self.copy_to_pipe, args=(self, stream, np))
                              for stream, np in
                              zip(self.streams, self.pipes)]

--- a/src/streamlink/utils/named_pipe.py
+++ b/src/streamlink/utils/named_pipe.py
@@ -1,10 +1,79 @@
+import abc
+import logging
 import os
+import random
 import tempfile
+import threading
 
 from streamlink.compat import is_py3, is_win32
 
 if is_win32:
     from ctypes import windll, cast, c_ulong, c_void_p, byref
+
+
+log = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_id = 0
+ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
+
+
+class NamedPipeBase(ABC):
+
+    def __init__(self):
+        global _id
+        with _lock:
+            _id += 1
+            self.name = "streamlinkpipe-{0}-{1}-{2}".format(os.getpid(), _id, random.randint(0, 9999))
+        log.info("Creating pipe {0}".format(self.name))
+        self._create()
+
+    @abc.abstractmethod
+    def _create(self):
+        # type: () -> None
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def open(self):
+        # type: () -> None
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def write(self, data):
+        # type: () -> int
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def close(self):
+        # type: () -> None
+        raise NotImplementedError
+
+
+class NamedPipePosix(NamedPipeBase):
+    mode = "wb"
+    permissions = 0o660
+    fifo = None
+
+    def _create(self):
+        self.path = os.path.join(tempfile.gettempdir(), self.name)
+        os.mkfifo(self.path, self.permissions)
+
+    def open(self):
+        self.fifo = open(self.path, self.mode)
+
+    def write(self, data):
+        return self.fifo.write(data)
+
+    def close(self):
+        if self.fifo is not None:
+            self.fifo.close()
+            self.fifo = None
+            os.unlink(self.path)
+
+
+class NamedPipeWindows(NamedPipeBase):
+    bufsize = 8192
+    pipe = None
 
     PIPE_ACCESS_OUTBOUND = 0x00000002
     PIPE_TYPE_BYTE = 0x00000000
@@ -13,60 +82,50 @@ if is_win32:
     PIPE_UNLIMITED_INSTANCES = 255
     INVALID_HANDLE_VALUE = -1
 
+    @staticmethod
+    def _get_last_error():
+        error_code = windll.kernel32.GetLastError()
+        raise OSError("Named pipe error code 0x{0:08X}".format(error_code))
 
-class NamedPipe(object):
-    def __init__(self, name):
-        self.fifo = None
-        self.pipe = None
-
-        if is_win32:
-            self.path = os.path.join("\\\\.\\pipe", name)
-            self.pipe = self._create_named_pipe(self.path)
-        else:
-            self.path = os.path.join(tempfile.gettempdir(), name)
-            self._create_fifo(self.path)
-
-    def _create_fifo(self, name):
-        os.mkfifo(name, 0o660)
-
-    def _create_named_pipe(self, path):
-        bufsize = 8192
-
+    def _create(self):
         if is_py3:
             create_named_pipe = windll.kernel32.CreateNamedPipeW
         else:
             create_named_pipe = windll.kernel32.CreateNamedPipeA
 
-        pipe = create_named_pipe(path, PIPE_ACCESS_OUTBOUND,
-                                 PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
-                                 PIPE_UNLIMITED_INSTANCES,
-                                 bufsize, bufsize,
-                                 0, None)
+        self.path = os.path.join("\\\\.\\pipe", self.name)
+        self.pipe = create_named_pipe(
+            self.path,
+            self.PIPE_ACCESS_OUTBOUND,
+            self.PIPE_TYPE_BYTE | self.PIPE_READMODE_BYTE | self.PIPE_WAIT,
+            self.PIPE_UNLIMITED_INSTANCES,
+            self.bufsize,
+            self.bufsize,
+            0,
+            None
+        )
+        if self.pipe == self.INVALID_HANDLE_VALUE:
+            self._get_last_error()
 
-        if pipe == INVALID_HANDLE_VALUE:
-            error_code = windll.kernel32.GetLastError()
-            raise IOError("Error code 0x{0:08X}".format(error_code))
-
-        return pipe
-
-    def open(self, mode):
-        if not self.pipe:
-            self.fifo = open(self.path, mode)
+    def open(self):
+        windll.kernel32.ConnectNamedPipe(self.pipe, None)
 
     def write(self, data):
-        if self.pipe:
-            windll.kernel32.ConnectNamedPipe(self.pipe, None)
-            written = c_ulong(0)
-            windll.kernel32.WriteFile(self.pipe, cast(data, c_void_p),
-                                      len(data), byref(written),
-                                      None)
-            return written
-        else:
-            return self.fifo.write(data)
+        written = c_ulong(0)
+        windll.kernel32.WriteFile(
+            self.pipe,
+            cast(data, c_void_p),
+            len(data),
+            byref(written),
+            None
+        )
+        return written.value
 
     def close(self):
-        if self.pipe:
+        if self.pipe is not None:
             windll.kernel32.DisconnectNamedPipe(self.pipe)
-        else:
-            self.fifo.close()
-            os.unlink(self.path)
+            windll.kernel32.CloseHandle(self.pipe)
+            self.pipe = None
+
+
+NamedPipe = NamedPipePosix if not is_win32 else NamedPipeWindows

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -97,12 +97,9 @@ def create_output(plugin):
                          "executable with --player.")
 
         if args.player_fifo:
-            pipename = "streamlinkpipe-{0}".format(os.getpid())
-            log.info("Creating pipe {0}".format(pipename))
-
             try:
-                namedpipe = NamedPipe(pipename)
-            except IOError as err:
+                namedpipe = NamedPipe()
+            except (IOError, OSError) as err:
                 console.exit("Failed to create pipe: {0}", err)
         elif args.player_http:
             http = create_http_server()

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -274,7 +274,7 @@ class PlayerOutput(Output):
             raise OSError("Process exited prematurely")
 
         if self.namedpipe:
-            self.namedpipe.open("wb")
+            self.namedpipe.open()
         elif self.http:
             self.http.open()
 

--- a/tests/test_utils_named_pipe.py
+++ b/tests/test_utils_named_pipe.py
@@ -1,0 +1,191 @@
+import os
+import stat
+import threading
+import unittest
+
+from streamlink.compat import is_py3, is_win32
+from streamlink.utils.named_pipe import NamedPipe, NamedPipePosix, NamedPipeWindows
+from tests.mock import Mock, call, patch
+
+if is_win32:
+    from ctypes import windll, create_string_buffer, c_ulong, byref
+
+
+GENERIC_READ = 0x80000000
+OPEN_EXISTING = 3
+
+
+class ReadNamedPipeThread(threading.Thread):
+    def __init__(self, pipe):
+        # type: NamedPipe
+        if is_py3:
+            super().__init__(daemon=True)
+        else:
+            super(ReadNamedPipeThread, self).__init__()
+            self.daemon = True
+        self.path = pipe.path
+        self.error = None
+        self.data = b""
+        self.done = threading.Event()
+
+    def run(self):
+        try:
+            self.read()
+        except OSError as err:  # pragma: no cover
+            self.error = err
+        self.done.set()
+
+    def read(self):
+        raise NotImplementedError
+
+
+class ReadNamedPipeThreadPosix(ReadNamedPipeThread):
+    def read(self):
+        with open(self.path, "rb") as file:
+            while True:
+                data = file.read(-1)
+                if len(data) == 0:
+                    break
+                self.data += data
+
+
+class ReadNamedPipeThreadWindows(ReadNamedPipeThread):
+    def read(self):
+        if is_py3:
+            create_file = windll.kernel32.CreateFileW
+        else:
+            create_file = windll.kernel32.CreateFileA
+        handle = create_file(self.path, GENERIC_READ, 0, None, OPEN_EXISTING, 0, None)
+        try:
+            while True:
+                data = create_string_buffer(NamedPipeWindows.bufsize)
+                read = c_ulong(0)
+                if not windll.kernel32.ReadFile(handle, data, NamedPipeWindows.bufsize, byref(read), None):  # pragma: no cover
+                    raise OSError("Failed reading pipe: {0}".format(windll.kernel32.GetLastError()))
+                self.data += data.value
+                if read.value != len(data.value):
+                    break
+        finally:
+            windll.kernel32.CloseHandle(handle)
+
+
+class TestNamedPipe(unittest.TestCase):
+    @patch("streamlink.utils.named_pipe._id", 0)
+    @patch("streamlink.utils.named_pipe.os.getpid", Mock(return_value=12345))
+    @patch("streamlink.utils.named_pipe.random.randint", Mock(return_value=67890))
+    @patch("streamlink.utils.named_pipe.NamedPipe._create", Mock(return_value=None))
+    @patch("streamlink.utils.named_pipe.log")
+    def test_name(self, mock_log):
+        NamedPipe()
+        NamedPipe()
+        self.assertEqual(mock_log.info.mock_calls, [
+            call("Creating pipe streamlinkpipe-12345-1-67890"),
+            call("Creating pipe streamlinkpipe-12345-2-67890")
+        ])
+
+
+@unittest.skipIf(is_win32, "test only applicable on a POSIX OS")
+class TestNamedPipePosix(unittest.TestCase):
+    def test_export(self):
+        self.assertEqual(NamedPipe, NamedPipePosix)
+
+    @patch("streamlink.utils.named_pipe.os.mkfifo")
+    def test_create(self, mock_mkfifo):
+        mock_mkfifo.side_effect = OSError()
+        with self.assertRaises(OSError):
+            NamedPipePosix()
+        self.assertEqual(mock_mkfifo.call_args[0][1:], (0o660,))
+
+    def test_close_before_open(self):
+        pipe = NamedPipePosix()
+        self.assertTrue(stat.S_ISFIFO(os.stat(pipe.path).st_mode))
+        pipe.close()
+        self.assertTrue(pipe.fifo is None)
+        self.assertFalse(os.path.isfile(pipe.path))
+        # closing twice doesn't raise
+        pipe.close()
+
+    def test_write_before_open(self):
+        pipe = NamedPipePosix()
+        self.assertTrue(stat.S_ISFIFO(os.stat(pipe.path).st_mode))
+        with self.assertRaises(Exception):
+            pipe.write(b"foo")
+        pipe.close()
+
+    def write_pipe(self, data, pipe):
+        if is_py3:
+            return pipe.write(data)
+        else:
+            pipe.write(data)
+            return len(data)
+
+    def test_named_pipe(self):
+        pipe = NamedPipePosix()
+        self.assertTrue(stat.S_ISFIFO(os.stat(pipe.path).st_mode))
+        reader = ReadNamedPipeThreadPosix(pipe)
+        reader.start()
+        pipe.open()
+        self.assertEqual(self.write_pipe(b"foo", pipe), 3)
+        self.assertEqual(self.write_pipe(b"bar", pipe), 3)
+        pipe.close()
+        self.assertFalse(os.path.isfile(pipe.path))
+        reader.done.wait(4000)
+        self.assertEqual(reader.error, None)
+        self.assertEqual(reader.data, b"foobar")
+        self.assertFalse(reader.is_alive())
+
+
+@unittest.skipIf(not is_win32, "test only applicable on Windows")
+class TestNamedPipeWindows(unittest.TestCase):
+    def test_export(self):
+        self.assertEqual(NamedPipe, NamedPipeWindows)
+
+    @patch("streamlink.utils.named_pipe.windll.kernel32")
+    def test_create(self, mock_kernel32):
+        if is_py3:
+            create_named_pipe = mock_kernel32.CreateNamedPipeW
+        else:
+            create_named_pipe = mock_kernel32.CreateNamedPipeA
+        create_named_pipe.return_value = NamedPipeWindows.INVALID_HANDLE_VALUE
+        mock_kernel32.GetLastError.return_value = 12345
+        with self.assertRaises(OSError) as cm:
+            NamedPipeWindows()
+        self.assertEqual(str(cm.exception), "Named pipe error code 0x00003039")
+        self.assertEqual(create_named_pipe.call_args[0][1:], (
+            0x00000002,
+            0x00000000,
+            255,
+            8192,
+            8192,
+            0,
+            None
+        ))
+
+    def test_close_before_open(self):
+        pipe = NamedPipeWindows()
+        if is_py3:
+            create_file = windll.kernel32.CreateFileW
+        else:
+            create_file = windll.kernel32.CreateFileA
+        handle = create_file(pipe.path, GENERIC_READ, 0, None, OPEN_EXISTING, 0, None)
+        self.assertNotEqual(handle, NamedPipeWindows.INVALID_HANDLE_VALUE)
+        windll.kernel32.CloseHandle(handle)
+        pipe.close()
+        handle = create_file(pipe.path, GENERIC_READ, 0, None, OPEN_EXISTING, 0, None)
+        self.assertEqual(handle, NamedPipeWindows.INVALID_HANDLE_VALUE)
+        # closing twice doesn't raise
+        pipe.close()
+
+    def test_named_pipe(self):
+        pipe = NamedPipeWindows()
+        reader = ReadNamedPipeThreadWindows(pipe)
+        reader.start()
+        pipe.open()
+        self.assertEqual(pipe.write(b"foo"), 3)
+        self.assertEqual(pipe.write(b"bar"), 3)
+        self.assertEqual(pipe.write(b"\0"), 1)
+        reader.done.wait(4000)
+        self.assertEqual(reader.error, None)
+        self.assertEqual(reader.data, b"foobar")
+        self.assertFalse(reader.is_alive())
+        pipe.close()


### PR DESCRIPTION
- split into two classes with an abstract base class
- remove name parameter from class and generate proper names
- remove mode parameter from open() as it's always binary mode
- change type of NamedPipe.path from str to pathlib.Path
- add tests

<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
